### PR TITLE
Event filtering

### DIFF
--- a/app/include/event_detector.h
+++ b/app/include/event_detector.h
@@ -65,6 +65,13 @@ public:
      */
 
     int get_fanotify_fd() const;
+
+    /**
+     * @brief Checks if the specified path is hidden.
+     * @param path The path to check.
+     * @return True if the path is hidden, false otherwise.
+     */
+    bool is_hidden_path(const std::string &path);
 };
 
 #endif // EVENT_DETECTOR_H

--- a/app/src/event_detector.cpp
+++ b/app/src/event_detector.cpp
@@ -8,6 +8,7 @@
 #include <sys/fanotify.h>
 #include <limits.h>
 #include <errno.h>
+#include <sstream>
 
 using namespace std;
 
@@ -42,6 +43,18 @@ void EventDetector::add_watch(const string& path) {
     } else {
         cout << "Watching " << path << endl;
     }
+}
+
+bool EventDetector::is_hidden_path(const string& path) {
+    stringstream ss(path);
+    string segmemnt;
+
+    while (getline(ss, segmemnt, '/')) {
+        if (segmemnt.length() > 0 && segmemnt[0] == '.') {
+            return true;
+        }
+    }
+    return false;
 }
 
 // Process events from the fanotify file descriptor

--- a/app/src/event_detector.cpp
+++ b/app/src/event_detector.cpp
@@ -88,38 +88,56 @@ void EventDetector::process_events() {
                 exit(EXIT_FAILURE);
             }
 
-            // Determine the type of event
-            switch (metadata->mask) {
-                case FAN_ATTRIB:
-                    str = "ATTRIB";
-                    break;
-                case FAN_CREATE:
-                    str = "CREATE";
-                    break;
-                case FAN_DELETE:
-                    str = "DELETE";
-                    break;
-                case FAN_DELETE_SELF:
-                    str = "DELETE SELF";
-                    break;
-                case FAN_MOVED_FROM:
-                    str = "MOVED FROM";
-                    break;
-                case FAN_MOVED_TO:
-                    str = "MOVED TO";
-                    break;
-                case FAN_MOVE_SELF:
-                    str = "MOVE SELF";
-                    break;
-                case FAN_CLOSE_WRITE:
-                    str = "FAN_CLOSE_WRITE";
-                    break;
-                default:
-                    str = "?";
-                    break;
-            }
-
             if (metadata->fd >= 0) {
+                // Get the path of the file associated with the event
+                sprintf(procfd_path, "/proc/self/fd/%d", metadata->fd);
+                path_len = readlink(procfd_path, path, sizeof(path) - 1);
+                if (path_len == -1) {
+                    perror("readlink");
+                    exit(EXIT_FAILURE);
+                }
+
+                path[path_len] = '\0';
+                string full_path(path);
+
+                // **Skip hidden files and directories BEFORE checking event type**
+                if (is_hidden_path(full_path)) {
+                    close(metadata->fd);
+                    metadata = FAN_EVENT_NEXT(metadata, len);
+                    continue;
+                }
+
+                // Determine the type of event
+                switch (metadata->mask) {
+                    case FAN_ATTRIB:
+                        str = "ATTRIB";
+                        break;
+                    case FAN_CREATE:
+                        str = "CREATE";
+                        break;
+                    case FAN_DELETE:
+                        str = "DELETE";
+                        break;
+                    case FAN_DELETE_SELF:
+                        str = "DELETE SELF";
+                        break;
+                    case FAN_MOVED_FROM:
+                        str = "MOVED FROM";
+                        break;
+                    case FAN_MOVED_TO:
+                        str = "MOVED TO";
+                        break;
+                    case FAN_MOVE_SELF:
+                        str = "MOVE SELF";
+                        break;
+                    case FAN_CLOSE_WRITE:
+                        str = "FAN_CLOSE_WRITE";
+                        break;
+                    default:
+                        str = "?";
+                        break;
+                }
+
                 // Handle permission events
                 if (metadata->mask & FAN_OPEN_PERM) {
                     printf("FAN_OPEN_PERM: ");
@@ -134,18 +152,7 @@ void EventDetector::process_events() {
                     printf("FAN_CLOSE_WRITE: ");
                 }
 
-                // Get the path of the file associated with the event
-                sprintf(procfd_path, "/proc/self/fd/%d", metadata->fd);
-                path_len = readlink(procfd_path, path, sizeof(path) - 1);
-                if (path_len == -1) {
-                    perror("readlink");
-                    exit(EXIT_FAILURE);
-                }
-
-                path[path_len] = '\0';
                 printf("File %s\n", path);
-
-                string full_path(path);
 
                 // Extract filename and extension from the full path
                 size_t last_slash = full_path.find_last_of("/");

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -26,7 +26,7 @@ int main(int argc, char* argv[]) {
     cout << "Is file an image?: " << is_image << endl;
 
     EventDetector detector;
-    detector.add_watch("/tmp");
+    detector.add_watch("/home");
 
     struct pollfd pfd;
     pfd.fd = detector.get_fanotify_fd();


### PR DESCRIPTION
Added a filter that removes all events that occur in a hidden file path. Not that there are still some system events that occur in non-hidden locations, like /var or /tmp.